### PR TITLE
Refactor to allow for a common settings menu

### DIFF
--- a/admin/class-wp-cxt-admin.php
+++ b/admin/class-wp-cxt-admin.php
@@ -47,7 +47,7 @@ class Wp_Cxt_Admin {
 
 		$screen = get_current_screen();
 		// only enqueue the chosen css on the specific WP Connext settings page
-		if ( ! empty( $screen->id ) && 'toplevel_page_mg2-top-menu' === $screen->id ) {
+		if ( ! empty( $screen->id ) && ( 'toplevel_page_mg2-top-menu' === $screen->id || 'mg2_page_wp-cxt' === $screen->id ) ) {
 			wp_enqueue_style( 'chosen', WP_CXT_URL . 'admin/css/chosen/chosen.min.css', array(), '1.7.0', 'all' );
 		}
 
@@ -62,7 +62,7 @@ class Wp_Cxt_Admin {
 
 		$screen = get_current_screen();
 		// only enqueue the chosen js and custom functionality on the specific WP Connext settings page
-		if ( ! empty( $screen->id ) && 'toplevel_page_mg2-top-menu' === $screen->id ) {
+		if ( ! empty( $screen->id ) && ( 'toplevel_page_mg2-top-menu' === $screen->id || 'mg2_page_wp-cxt' === $screen->id ) ) {
 			wp_enqueue_script( 'chosen', WP_CXT_URL . 'admin/js/chosen/chosen.jquery.min.js', array( 'jquery' ), '1.7.0', true );
 			wp_enqueue_script( 'wp-cxt-admin', WP_CXT_URL . 'admin/js/wp-cxt-admin.js', array( 'chosen' ), WP_CXT_VERSION, true );
 		}

--- a/admin/class-wp-cxt-admin.php
+++ b/admin/class-wp-cxt-admin.php
@@ -47,7 +47,7 @@ class Wp_Cxt_Admin {
 
 		$screen = get_current_screen();
 		// only enqueue the chosen css on the specific WP Connext settings page
-		if ( ! empty( $screen->id ) && 'settings_page_wp-cxt' === $screen->id ) {
+		if ( ! empty( $screen->id ) && 'toplevel_page_mg2-top-menu' === $screen->id ) {
 			wp_enqueue_style( 'chosen', WP_CXT_URL . 'admin/css/chosen/chosen.min.css', array(), '1.7.0', 'all' );
 		}
 
@@ -62,7 +62,7 @@ class Wp_Cxt_Admin {
 
 		$screen = get_current_screen();
 		// only enqueue the chosen js and custom functionality on the specific WP Connext settings page
-		if ( ! empty( $screen->id ) && 'settings_page_wp-cxt' === $screen->id ) {
+		if ( ! empty( $screen->id ) && 'toplevel_page_mg2-top-menu' === $screen->id ) {
 			wp_enqueue_script( 'chosen', WP_CXT_URL . 'admin/js/chosen/chosen.jquery.min.js', array( 'jquery' ), '1.7.0', true );
 			wp_enqueue_script( 'wp-cxt-admin', WP_CXT_URL . 'admin/js/wp-cxt-admin.js', array( 'chosen' ), WP_CXT_VERSION, true );
 		}

--- a/admin/class-wp-cxt-settings-page.php
+++ b/admin/class-wp-cxt-settings-page.php
@@ -42,6 +42,7 @@ class Wp_Cxt_Settings_Page {
 
 		<div class="wrap <?php echo esc_attr( $this->plugin_name ); ?>">
 			<h2><?php echo esc_html__( 'Connext Settings', 'wp-cxt' ); ?></h2>
+			<?php settings_errors(); ?>
 			<form action="options.php" method="post">
 
 				<?php settings_fields( $this->plugin_name ); ?>

--- a/admin/class-wp-cxt-settings.php
+++ b/admin/class-wp-cxt-settings.php
@@ -46,13 +46,14 @@ class Wp_Cxt_Settings {
 	public function initialize_settings_page() {
 
 		$settings_page = new Wp_Cxt_Settings_Page( $this->plugin_name );
+		$is_first_submenu = $this->is_first_submenu();
 
 		add_submenu_page(
-			'options-general.php',
+			'mg2-top-menu',
 			__( 'Connext Settings', 'wp-cxt' ),
 			__( 'Connext Settings', 'wp-cxt' ),
 			'manage_options',
-			$this->plugin_name,
+			$is_first_submenu ? 'mg2-top-menu' : $this->plugin_name,
 			array( $settings_page, 'render_page' )
 		);
 	}
@@ -438,6 +439,38 @@ class Wp_Cxt_Settings {
 			$term_options[ $term->term_id ] = $term->name;
 		}
 		return $term_options;
+	}
+
+	/**
+	 * Determines whether or not this is the first MG2
+	 * submenu to be registered under the parent MG2 page.
+	 *
+	 * @return bool
+	 */
+	private function is_first_submenu() {
+		global $admin_page_hooks;
+		if ( empty( $admin_page_hooks['mg2-top-menu'] ) ) {
+			$this->create_top_menu();
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Creates an initial top level menu for any
+	 * MG2 plugins that may be installed.
+	 *
+	 * @return void
+	 */
+	private function create_top_menu() {
+		add_menu_page(
+			__( 'MG2', 'wp-cxt' ),
+			__( 'MG2', 'wp-cxt' ),
+			'manage_options',
+			'mg2-top-menu',
+			'__return_null',
+			'dashicons-admin-generic'
+		);
 	}
 
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-cxt",
-  "version": "0.1.0",
+  "version": "1.6.2",
   "repository": {
     "type": "git",
     "url": "git@github.com:marketingg2/connext-wp-vip.git"

--- a/public/class-wp-cxt-public.php
+++ b/public/class-wp-cxt-public.php
@@ -115,9 +115,9 @@ class Wp_Cxt_Public {
 	 */
 	private function connext_enabled() {
 		// First determine if the home page or front page are enabled
-		if ( is_home() && ! empty( $this->current_settings['display_home'] && 'yes' === $this->current_settings['display_home'] ) ) {
+		if ( is_home() && ! empty( $this->current_settings['display_home'] ) && 'yes' === $this->current_settings['display_home'] ) {
 			return true;
-		} elseif ( is_front_page() && ! empty( $this->current_settings['display_front'] && 'yes' === $this->current_settings['display_front'] ) ) {
+		} elseif ( is_front_page() && ! empty( $this->current_settings['display_front'] ) && 'yes' === $this->current_settings['display_front'] ) {
 			return true;
 		} elseif ( is_category() || is_tag() || is_tax() ) {
 			$term = get_queried_object();

--- a/wp-cxt.php
+++ b/wp-cxt.php
@@ -16,7 +16,7 @@
  * Plugin Name:       Connext
  * Plugin URI:        http://marketingg2.com
  * Description:       To enable Connext pleasce contact your project manager for site configuration data.
- * Version:           1.0.0
+ * Version:           1.6.2
  * Author:            Marketing G2
  * Author URI:        http://marketingg2.com
  * License:           GPL-2.0+
@@ -33,7 +33,7 @@ if ( ! defined( 'WPINC' ) ) {
 define( 'WP_CXT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'WP_CXT_URL', plugin_dir_url( __FILE__ ) );
 define( 'WP_CXT_BASENAME', plugin_basename( __FILE__ ) );
-define( 'WP_CXT_VERSION', '1.0.0' );
+define( 'WP_CXT_VERSION', '1.6.2' );
 
 /**
  * The core plugin class that is used to define internationalization,


### PR DESCRIPTION
This allows the plugin to check for (and optionally create) a common top level menu for all MG2 WordPress plugins. Also bumps versions to resolve #4.